### PR TITLE
Support schemas that use the same CustomType multiple times

### DIFF
--- a/internal/cmd/generate_data_sources.go
+++ b/internal/cmd/generate_data_sources.go
@@ -106,6 +106,7 @@ func (cmd *GenerateDataSourcesCommand) Run(args []string) int {
 }
 
 func (cmd *GenerateDataSourcesCommand) runInternal(ctx context.Context, logger *slog.Logger) error {
+
 	// read input file
 	src, err := input.Read(cmd.flagIRInputPath)
 	if err != nil {
@@ -133,6 +134,8 @@ func (cmd *GenerateDataSourcesCommand) runInternal(ctx context.Context, logger *
 }
 
 func generateDataSourceCode(ctx context.Context, spec spec.Specification, outputPath, packageName, generatorType string, logger *slog.Logger) error {
+	renderstate := schema.NewRenderState()
+
 	ctxWithPath := logging.SetPathInContext(ctx, "data_source")
 
 	// convert IR to framework schema
@@ -155,7 +158,7 @@ func generateDataSourceCode(ctx context.Context, spec spec.Specification, output
 	}
 
 	// generate custom type and value types code
-	customTypeValue, err := g.CustomTypeValue()
+	customTypeValue, err := g.CustomTypeValue(&renderstate)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/cmd/generate_provider.go
+++ b/internal/cmd/generate_provider.go
@@ -106,6 +106,7 @@ func (cmd *GenerateProviderCommand) Run(args []string) int {
 }
 
 func (cmd *GenerateProviderCommand) runInternal(ctx context.Context, logger *slog.Logger) error {
+
 	// read input file
 	src, err := input.Read(cmd.flagIRInputPath)
 	if err != nil {
@@ -133,6 +134,8 @@ func (cmd *GenerateProviderCommand) runInternal(ctx context.Context, logger *slo
 }
 
 func generateProviderCode(ctx context.Context, spec spec.Specification, outputPath, packageName, generatorType string, logger *slog.Logger) error {
+	renderstate := schema.NewRenderState()
+
 	ctx = logging.SetPathInContext(ctx, "provider")
 
 	// convert IR to framework schema
@@ -155,7 +158,7 @@ func generateProviderCode(ctx context.Context, spec spec.Specification, outputPa
 	}
 
 	// generate custom type and value types code
-	customTypeValue, err := g.CustomTypeValue()
+	customTypeValue, err := g.CustomTypeValue(&renderstate)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/cmd/generate_resources.go
+++ b/internal/cmd/generate_resources.go
@@ -106,6 +106,7 @@ func (cmd *GenerateResourcesCommand) Run(args []string) int {
 }
 
 func (cmd *GenerateResourcesCommand) runInternal(ctx context.Context, logger *slog.Logger) error {
+
 	// read input file
 	src, err := input.Read(cmd.flagIRInputPath)
 	if err != nil {
@@ -133,6 +134,8 @@ func (cmd *GenerateResourcesCommand) runInternal(ctx context.Context, logger *sl
 }
 
 func generateResourceCode(ctx context.Context, spec spec.Specification, outputPath, packageName, generatorType string, logger *slog.Logger) error {
+	renderstate := schema.NewRenderState()
+
 	ctx = logging.SetPathInContext(ctx, "resource")
 
 	// convert IR to framework schema
@@ -155,7 +158,7 @@ func generateResourceCode(ctx context.Context, spec spec.Specification, outputPa
 	}
 
 	// generate custom type and value types code
-	customTypeValue, err := g.CustomTypeValue()
+	customTypeValue, err := g.CustomTypeValue(&renderstate)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/resource_example/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/default_pkg_name/resource_example/example_resource_gen.go
@@ -38,6 +38,52 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 				},
 				Default: booldefault.StaticBool(true),
 			},
+			"duplicated_custom_type1": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"duplicated": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"something": schema.StringAttribute{
+								Required: true,
+							},
+						},
+						CustomType: DuplicatedType{
+							ObjectType: types.ObjectType{
+								AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+							},
+						},
+						Required: true,
+					},
+				},
+				CustomType: DuplicatedCustomType1Type{
+					ObjectType: types.ObjectType{
+						AttrTypes: DuplicatedCustomType1Value{}.AttributeTypes(ctx),
+					},
+				},
+				Optional: true,
+			},
+			"duplicated_custom_type2": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"duplicated": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"something": schema.StringAttribute{
+								Required: true,
+							},
+						},
+						CustomType: DuplicatedType{
+							ObjectType: types.ObjectType{
+								AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+							},
+						},
+						Required: true,
+					},
+				},
+				CustomType: DuplicatedCustomType2Type{
+					ObjectType: types.ObjectType{
+						AttrTypes: DuplicatedCustomType2Value{}.AttributeTypes(ctx),
+					},
+				},
+				Optional: true,
+			},
 			"int64_attribute_write_only": schema.Int64Attribute{
 				Optional:  true,
 				WriteOnly: true,
@@ -235,6 +281,8 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 
 type ExampleModel struct {
 	BoolAttribute                     my_bool_value                          `tfsdk:"bool_attribute"`
+	DuplicatedCustomType1             DuplicatedCustomType1Value             `tfsdk:"duplicated_custom_type1"`
+	DuplicatedCustomType2             DuplicatedCustomType2Value             `tfsdk:"duplicated_custom_type2"`
 	Int64AttributeWriteOnly           types.Int64                            `tfsdk:"int64_attribute_write_only"`
 	ListNestedAttributeAssocExtType   types.List                             `tfsdk:"list_nested_attribute_assoc_ext_type"`
 	MapNestedAttributeAssocExtType    types.Map                              `tfsdk:"map_nested_attribute_assoc_ext_type"`
@@ -244,6 +292,1035 @@ type ExampleModel struct {
 	SetNestedBlockAssocExtType        types.Set                              `tfsdk:"set_nested_block_assoc_ext_type"`
 	SingleNestedBlockAssocExtType     SingleNestedBlockAssocExtTypeValue     `tfsdk:"single_nested_block_assoc_ext_type"`
 }
+
+var _ basetypes.ObjectTypable = DuplicatedCustomType1Type{}
+
+type DuplicatedCustomType1Type struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedCustomType1Type) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedCustomType1Type)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedCustomType1Type) String() string {
+	return "DuplicatedCustomType1Type"
+}
+
+func (t DuplicatedCustomType1Type) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return nil, diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedCustomType1Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType1ValueNull() DuplicatedCustomType1Value {
+	return DuplicatedCustomType1Value{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedCustomType1ValueUnknown() DuplicatedCustomType1Value {
+	return DuplicatedCustomType1Value{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedCustomType1Value(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedCustomType1Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedCustomType1Value Attribute Value",
+				"While creating a DuplicatedCustomType1Value value, a missing attribute value was detected. "+
+					"A DuplicatedCustomType1Value must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedCustomType1Value Attribute Type",
+				"While creating a DuplicatedCustomType1Value value, an invalid attribute value was detected. "+
+					"A DuplicatedCustomType1Value must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedCustomType1Value Attribute Value",
+				"While creating a DuplicatedCustomType1Value value, an extra attribute value was detected. "+
+					"A DuplicatedCustomType1Value must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedCustomType1Value Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	return DuplicatedCustomType1Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType1ValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedCustomType1Value {
+	object, diags := NewDuplicatedCustomType1Value(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedCustomType1ValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedCustomType1Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedCustomType1ValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedCustomType1ValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedCustomType1ValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedCustomType1ValueMust(DuplicatedCustomType1Value{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedCustomType1Type) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedCustomType1Value{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedCustomType1Value{}
+
+type DuplicatedCustomType1Value struct {
+	Duplicated basetypes.ObjectValue `tfsdk:"duplicated"`
+	state      attr.ValueState
+}
+
+func (v DuplicatedCustomType1Value) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["duplicated"] = basetypes.ObjectType{
+		AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Duplicated.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["duplicated"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedCustomType1Value) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedCustomType1Value) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedCustomType1Value) String() string {
+	return "DuplicatedCustomType1Value"
+}
+
+func (v DuplicatedCustomType1Value) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var duplicated basetypes.ObjectValue
+
+	if v.Duplicated.IsNull() {
+		duplicated = types.ObjectNull(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectUnknown(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if !v.Duplicated.IsNull() && !v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectValueMust(
+			DuplicatedValue{}.AttributeTypes(ctx),
+			v.Duplicated.Attributes(),
+		)
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"duplicated": duplicated,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedCustomType1Value) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedCustomType1Value)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Duplicated.Equal(other.Duplicated) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedCustomType1Value) Type(ctx context.Context) attr.Type {
+	return DuplicatedCustomType1Type{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedCustomType1Value) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+}
+
+var _ basetypes.ObjectTypable = DuplicatedType{}
+
+type DuplicatedType struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedType) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedType) String() string {
+	return "DuplicatedType"
+}
+
+func (t DuplicatedType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	somethingAttribute, ok := attributes["something"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`something is missing from object`)
+
+		return nil, diags
+	}
+
+	somethingVal, ok := somethingAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`something expected to be basetypes.StringValue, was: %T`, somethingAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedValue{
+		Something: somethingVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedValueNull() DuplicatedValue {
+	return DuplicatedValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedValueUnknown() DuplicatedValue {
+	return DuplicatedValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedValue Attribute Value",
+				"While creating a DuplicatedValue value, a missing attribute value was detected. "+
+					"A DuplicatedValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedValue Attribute Type",
+				"While creating a DuplicatedValue value, an invalid attribute value was detected. "+
+					"A DuplicatedValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedValue Attribute Value",
+				"While creating a DuplicatedValue value, an extra attribute value was detected. "+
+					"A DuplicatedValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	somethingAttribute, ok := attributes["something"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`something is missing from object`)
+
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	somethingVal, ok := somethingAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`something expected to be basetypes.StringValue, was: %T`, somethingAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	return DuplicatedValue{
+		Something: somethingVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedValue {
+	object, diags := NewDuplicatedValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedValueMust(DuplicatedValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedType) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedValue{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedValue{}
+
+type DuplicatedValue struct {
+	Something basetypes.StringValue `tfsdk:"something"`
+	state     attr.ValueState
+}
+
+func (v DuplicatedValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["something"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Something.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["something"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedValue) String() string {
+	return "DuplicatedValue"
+}
+
+func (v DuplicatedValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"something": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"something": v.Something,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedValue) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Something.Equal(other.Something) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedValue) Type(ctx context.Context) attr.Type {
+	return DuplicatedType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"something": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = DuplicatedCustomType2Type{}
+
+type DuplicatedCustomType2Type struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedCustomType2Type) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedCustomType2Type)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedCustomType2Type) String() string {
+	return "DuplicatedCustomType2Type"
+}
+
+func (t DuplicatedCustomType2Type) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return nil, diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedCustomType2Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType2ValueNull() DuplicatedCustomType2Value {
+	return DuplicatedCustomType2Value{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedCustomType2ValueUnknown() DuplicatedCustomType2Value {
+	return DuplicatedCustomType2Value{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedCustomType2Value(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedCustomType2Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedCustomType2Value Attribute Value",
+				"While creating a DuplicatedCustomType2Value value, a missing attribute value was detected. "+
+					"A DuplicatedCustomType2Value must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedCustomType2Value Attribute Type",
+				"While creating a DuplicatedCustomType2Value value, an invalid attribute value was detected. "+
+					"A DuplicatedCustomType2Value must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedCustomType2Value Attribute Value",
+				"While creating a DuplicatedCustomType2Value value, an extra attribute value was detected. "+
+					"A DuplicatedCustomType2Value must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedCustomType2Value Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	return DuplicatedCustomType2Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType2ValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedCustomType2Value {
+	object, diags := NewDuplicatedCustomType2Value(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedCustomType2ValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedCustomType2Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedCustomType2ValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedCustomType2ValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedCustomType2ValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedCustomType2ValueMust(DuplicatedCustomType2Value{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedCustomType2Type) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedCustomType2Value{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedCustomType2Value{}
+
+type DuplicatedCustomType2Value struct {
+	Duplicated basetypes.ObjectValue `tfsdk:"duplicated"`
+	state      attr.ValueState
+}
+
+func (v DuplicatedCustomType2Value) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["duplicated"] = basetypes.ObjectType{
+		AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Duplicated.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["duplicated"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedCustomType2Value) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedCustomType2Value) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedCustomType2Value) String() string {
+	return "DuplicatedCustomType2Value"
+}
+
+func (v DuplicatedCustomType2Value) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var duplicated basetypes.ObjectValue
+
+	if v.Duplicated.IsNull() {
+		duplicated = types.ObjectNull(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectUnknown(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if !v.Duplicated.IsNull() && !v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectValueMust(
+			DuplicatedValue{}.AttributeTypes(ctx),
+			v.Duplicated.Attributes(),
+		)
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"duplicated": duplicated,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedCustomType2Value) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedCustomType2Value)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Duplicated.Equal(other.Duplicated) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedCustomType2Value) Type(ctx context.Context) attr.Type {
+	return DuplicatedCustomType2Type{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedCustomType2Value) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+}
+
+// already written CustomNestedObjectType: duplicated
+// already written CustomNestedObjectValue: duplicated
 
 var _ basetypes.ObjectTypable = ListNestedAttributeAssocExtTypeType{}
 

--- a/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/all_output/specified_pkg_name/example_resource_gen.go
@@ -38,6 +38,52 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 				},
 				Default: booldefault.StaticBool(true),
 			},
+			"duplicated_custom_type1": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"duplicated": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"something": schema.StringAttribute{
+								Required: true,
+							},
+						},
+						CustomType: DuplicatedType{
+							ObjectType: types.ObjectType{
+								AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+							},
+						},
+						Required: true,
+					},
+				},
+				CustomType: DuplicatedCustomType1Type{
+					ObjectType: types.ObjectType{
+						AttrTypes: DuplicatedCustomType1Value{}.AttributeTypes(ctx),
+					},
+				},
+				Optional: true,
+			},
+			"duplicated_custom_type2": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"duplicated": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"something": schema.StringAttribute{
+								Required: true,
+							},
+						},
+						CustomType: DuplicatedType{
+							ObjectType: types.ObjectType{
+								AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+							},
+						},
+						Required: true,
+					},
+				},
+				CustomType: DuplicatedCustomType2Type{
+					ObjectType: types.ObjectType{
+						AttrTypes: DuplicatedCustomType2Value{}.AttributeTypes(ctx),
+					},
+				},
+				Optional: true,
+			},
 			"int64_attribute_write_only": schema.Int64Attribute{
 				Optional:  true,
 				WriteOnly: true,
@@ -235,6 +281,8 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 
 type ExampleModel struct {
 	BoolAttribute                     my_bool_value                          `tfsdk:"bool_attribute"`
+	DuplicatedCustomType1             DuplicatedCustomType1Value             `tfsdk:"duplicated_custom_type1"`
+	DuplicatedCustomType2             DuplicatedCustomType2Value             `tfsdk:"duplicated_custom_type2"`
 	Int64AttributeWriteOnly           types.Int64                            `tfsdk:"int64_attribute_write_only"`
 	ListNestedAttributeAssocExtType   types.List                             `tfsdk:"list_nested_attribute_assoc_ext_type"`
 	MapNestedAttributeAssocExtType    types.Map                              `tfsdk:"map_nested_attribute_assoc_ext_type"`
@@ -244,6 +292,1035 @@ type ExampleModel struct {
 	SetNestedBlockAssocExtType        types.Set                              `tfsdk:"set_nested_block_assoc_ext_type"`
 	SingleNestedBlockAssocExtType     SingleNestedBlockAssocExtTypeValue     `tfsdk:"single_nested_block_assoc_ext_type"`
 }
+
+var _ basetypes.ObjectTypable = DuplicatedCustomType1Type{}
+
+type DuplicatedCustomType1Type struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedCustomType1Type) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedCustomType1Type)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedCustomType1Type) String() string {
+	return "DuplicatedCustomType1Type"
+}
+
+func (t DuplicatedCustomType1Type) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return nil, diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedCustomType1Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType1ValueNull() DuplicatedCustomType1Value {
+	return DuplicatedCustomType1Value{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedCustomType1ValueUnknown() DuplicatedCustomType1Value {
+	return DuplicatedCustomType1Value{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedCustomType1Value(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedCustomType1Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedCustomType1Value Attribute Value",
+				"While creating a DuplicatedCustomType1Value value, a missing attribute value was detected. "+
+					"A DuplicatedCustomType1Value must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedCustomType1Value Attribute Type",
+				"While creating a DuplicatedCustomType1Value value, an invalid attribute value was detected. "+
+					"A DuplicatedCustomType1Value must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedCustomType1Value Attribute Value",
+				"While creating a DuplicatedCustomType1Value value, an extra attribute value was detected. "+
+					"A DuplicatedCustomType1Value must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedCustomType1Value Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	return DuplicatedCustomType1Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType1ValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedCustomType1Value {
+	object, diags := NewDuplicatedCustomType1Value(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedCustomType1ValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedCustomType1Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedCustomType1ValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedCustomType1ValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedCustomType1ValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedCustomType1ValueMust(DuplicatedCustomType1Value{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedCustomType1Type) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedCustomType1Value{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedCustomType1Value{}
+
+type DuplicatedCustomType1Value struct {
+	Duplicated basetypes.ObjectValue `tfsdk:"duplicated"`
+	state      attr.ValueState
+}
+
+func (v DuplicatedCustomType1Value) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["duplicated"] = basetypes.ObjectType{
+		AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Duplicated.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["duplicated"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedCustomType1Value) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedCustomType1Value) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedCustomType1Value) String() string {
+	return "DuplicatedCustomType1Value"
+}
+
+func (v DuplicatedCustomType1Value) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var duplicated basetypes.ObjectValue
+
+	if v.Duplicated.IsNull() {
+		duplicated = types.ObjectNull(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectUnknown(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if !v.Duplicated.IsNull() && !v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectValueMust(
+			DuplicatedValue{}.AttributeTypes(ctx),
+			v.Duplicated.Attributes(),
+		)
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"duplicated": duplicated,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedCustomType1Value) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedCustomType1Value)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Duplicated.Equal(other.Duplicated) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedCustomType1Value) Type(ctx context.Context) attr.Type {
+	return DuplicatedCustomType1Type{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedCustomType1Value) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+}
+
+var _ basetypes.ObjectTypable = DuplicatedType{}
+
+type DuplicatedType struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedType) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedType) String() string {
+	return "DuplicatedType"
+}
+
+func (t DuplicatedType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	somethingAttribute, ok := attributes["something"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`something is missing from object`)
+
+		return nil, diags
+	}
+
+	somethingVal, ok := somethingAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`something expected to be basetypes.StringValue, was: %T`, somethingAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedValue{
+		Something: somethingVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedValueNull() DuplicatedValue {
+	return DuplicatedValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedValueUnknown() DuplicatedValue {
+	return DuplicatedValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedValue Attribute Value",
+				"While creating a DuplicatedValue value, a missing attribute value was detected. "+
+					"A DuplicatedValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedValue Attribute Type",
+				"While creating a DuplicatedValue value, an invalid attribute value was detected. "+
+					"A DuplicatedValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedValue Attribute Value",
+				"While creating a DuplicatedValue value, an extra attribute value was detected. "+
+					"A DuplicatedValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	somethingAttribute, ok := attributes["something"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`something is missing from object`)
+
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	somethingVal, ok := somethingAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`something expected to be basetypes.StringValue, was: %T`, somethingAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	return DuplicatedValue{
+		Something: somethingVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedValue {
+	object, diags := NewDuplicatedValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedValueMust(DuplicatedValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedType) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedValue{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedValue{}
+
+type DuplicatedValue struct {
+	Something basetypes.StringValue `tfsdk:"something"`
+	state     attr.ValueState
+}
+
+func (v DuplicatedValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["something"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Something.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["something"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedValue) String() string {
+	return "DuplicatedValue"
+}
+
+func (v DuplicatedValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"something": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"something": v.Something,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedValue) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Something.Equal(other.Something) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedValue) Type(ctx context.Context) attr.Type {
+	return DuplicatedType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"something": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = DuplicatedCustomType2Type{}
+
+type DuplicatedCustomType2Type struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedCustomType2Type) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedCustomType2Type)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedCustomType2Type) String() string {
+	return "DuplicatedCustomType2Type"
+}
+
+func (t DuplicatedCustomType2Type) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return nil, diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedCustomType2Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType2ValueNull() DuplicatedCustomType2Value {
+	return DuplicatedCustomType2Value{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedCustomType2ValueUnknown() DuplicatedCustomType2Value {
+	return DuplicatedCustomType2Value{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedCustomType2Value(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedCustomType2Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedCustomType2Value Attribute Value",
+				"While creating a DuplicatedCustomType2Value value, a missing attribute value was detected. "+
+					"A DuplicatedCustomType2Value must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedCustomType2Value Attribute Type",
+				"While creating a DuplicatedCustomType2Value value, an invalid attribute value was detected. "+
+					"A DuplicatedCustomType2Value must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedCustomType2Value Attribute Value",
+				"While creating a DuplicatedCustomType2Value value, an extra attribute value was detected. "+
+					"A DuplicatedCustomType2Value must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedCustomType2Value Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	return DuplicatedCustomType2Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType2ValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedCustomType2Value {
+	object, diags := NewDuplicatedCustomType2Value(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedCustomType2ValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedCustomType2Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedCustomType2ValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedCustomType2ValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedCustomType2ValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedCustomType2ValueMust(DuplicatedCustomType2Value{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedCustomType2Type) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedCustomType2Value{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedCustomType2Value{}
+
+type DuplicatedCustomType2Value struct {
+	Duplicated basetypes.ObjectValue `tfsdk:"duplicated"`
+	state      attr.ValueState
+}
+
+func (v DuplicatedCustomType2Value) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["duplicated"] = basetypes.ObjectType{
+		AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Duplicated.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["duplicated"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedCustomType2Value) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedCustomType2Value) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedCustomType2Value) String() string {
+	return "DuplicatedCustomType2Value"
+}
+
+func (v DuplicatedCustomType2Value) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var duplicated basetypes.ObjectValue
+
+	if v.Duplicated.IsNull() {
+		duplicated = types.ObjectNull(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectUnknown(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if !v.Duplicated.IsNull() && !v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectValueMust(
+			DuplicatedValue{}.AttributeTypes(ctx),
+			v.Duplicated.Attributes(),
+		)
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"duplicated": duplicated,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedCustomType2Value) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedCustomType2Value)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Duplicated.Equal(other.Duplicated) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedCustomType2Value) Type(ctx context.Context) attr.Type {
+	return DuplicatedCustomType2Type{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedCustomType2Value) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+}
+
+// already written CustomNestedObjectType: duplicated
+// already written CustomNestedObjectValue: duplicated
 
 var _ basetypes.ObjectTypable = ListNestedAttributeAssocExtTypeType{}
 

--- a/internal/cmd/testdata/custom_and_external/ir.json
+++ b/internal/cmd/testdata/custom_and_external/ir.json
@@ -1316,6 +1316,50 @@
               "computed_optional_required": "optional",
               "write_only": true
             }
+          },
+          {
+            "name": "duplicated_custom_type1",
+            "single_nested": {
+              "computed_optional_required": "optional",
+              "attributes": [
+                {
+                  "name": "duplicated",
+                  "single_nested": {
+                    "computed_optional_required": "required",
+                    "attributes": [
+                      {
+                        "name": "something",
+                        "string": {
+                          "computed_optional_required": "required"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "duplicated_custom_type2",
+            "single_nested": {
+              "computed_optional_required": "optional",
+              "attributes": [
+                {
+                  "name": "duplicated",
+                  "single_nested": {
+                    "computed_optional_required": "required",
+                    "attributes": [
+                      {
+                        "name": "something",
+                        "string": {
+                          "computed_optional_required": "required"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
           }
         ],
         "blocks": [

--- a/internal/cmd/testdata/custom_and_external/resources_output/example_resource_gen.go
+++ b/internal/cmd/testdata/custom_and_external/resources_output/example_resource_gen.go
@@ -38,6 +38,52 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 				},
 				Default: booldefault.StaticBool(true),
 			},
+			"duplicated_custom_type1": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"duplicated": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"something": schema.StringAttribute{
+								Required: true,
+							},
+						},
+						CustomType: DuplicatedType{
+							ObjectType: types.ObjectType{
+								AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+							},
+						},
+						Required: true,
+					},
+				},
+				CustomType: DuplicatedCustomType1Type{
+					ObjectType: types.ObjectType{
+						AttrTypes: DuplicatedCustomType1Value{}.AttributeTypes(ctx),
+					},
+				},
+				Optional: true,
+			},
+			"duplicated_custom_type2": schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"duplicated": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"something": schema.StringAttribute{
+								Required: true,
+							},
+						},
+						CustomType: DuplicatedType{
+							ObjectType: types.ObjectType{
+								AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+							},
+						},
+						Required: true,
+					},
+				},
+				CustomType: DuplicatedCustomType2Type{
+					ObjectType: types.ObjectType{
+						AttrTypes: DuplicatedCustomType2Value{}.AttributeTypes(ctx),
+					},
+				},
+				Optional: true,
+			},
 			"int64_attribute_write_only": schema.Int64Attribute{
 				Optional:  true,
 				WriteOnly: true,
@@ -235,6 +281,8 @@ func ExampleResourceSchema(ctx context.Context) schema.Schema {
 
 type ExampleModel struct {
 	BoolAttribute                     my_bool_value                          `tfsdk:"bool_attribute"`
+	DuplicatedCustomType1             DuplicatedCustomType1Value             `tfsdk:"duplicated_custom_type1"`
+	DuplicatedCustomType2             DuplicatedCustomType2Value             `tfsdk:"duplicated_custom_type2"`
 	Int64AttributeWriteOnly           types.Int64                            `tfsdk:"int64_attribute_write_only"`
 	ListNestedAttributeAssocExtType   types.List                             `tfsdk:"list_nested_attribute_assoc_ext_type"`
 	MapNestedAttributeAssocExtType    types.Map                              `tfsdk:"map_nested_attribute_assoc_ext_type"`
@@ -244,6 +292,1035 @@ type ExampleModel struct {
 	SetNestedBlockAssocExtType        types.Set                              `tfsdk:"set_nested_block_assoc_ext_type"`
 	SingleNestedBlockAssocExtType     SingleNestedBlockAssocExtTypeValue     `tfsdk:"single_nested_block_assoc_ext_type"`
 }
+
+var _ basetypes.ObjectTypable = DuplicatedCustomType1Type{}
+
+type DuplicatedCustomType1Type struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedCustomType1Type) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedCustomType1Type)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedCustomType1Type) String() string {
+	return "DuplicatedCustomType1Type"
+}
+
+func (t DuplicatedCustomType1Type) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return nil, diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedCustomType1Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType1ValueNull() DuplicatedCustomType1Value {
+	return DuplicatedCustomType1Value{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedCustomType1ValueUnknown() DuplicatedCustomType1Value {
+	return DuplicatedCustomType1Value{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedCustomType1Value(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedCustomType1Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedCustomType1Value Attribute Value",
+				"While creating a DuplicatedCustomType1Value value, a missing attribute value was detected. "+
+					"A DuplicatedCustomType1Value must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedCustomType1Value Attribute Type",
+				"While creating a DuplicatedCustomType1Value value, an invalid attribute value was detected. "+
+					"A DuplicatedCustomType1Value must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedCustomType1Value Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedCustomType1Value Attribute Value",
+				"While creating a DuplicatedCustomType1Value value, an extra attribute value was detected. "+
+					"A DuplicatedCustomType1Value must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedCustomType1Value Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType1ValueUnknown(), diags
+	}
+
+	return DuplicatedCustomType1Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType1ValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedCustomType1Value {
+	object, diags := NewDuplicatedCustomType1Value(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedCustomType1ValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedCustomType1Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedCustomType1ValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedCustomType1ValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedCustomType1ValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedCustomType1ValueMust(DuplicatedCustomType1Value{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedCustomType1Type) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedCustomType1Value{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedCustomType1Value{}
+
+type DuplicatedCustomType1Value struct {
+	Duplicated basetypes.ObjectValue `tfsdk:"duplicated"`
+	state      attr.ValueState
+}
+
+func (v DuplicatedCustomType1Value) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["duplicated"] = basetypes.ObjectType{
+		AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Duplicated.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["duplicated"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedCustomType1Value) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedCustomType1Value) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedCustomType1Value) String() string {
+	return "DuplicatedCustomType1Value"
+}
+
+func (v DuplicatedCustomType1Value) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var duplicated basetypes.ObjectValue
+
+	if v.Duplicated.IsNull() {
+		duplicated = types.ObjectNull(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectUnknown(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if !v.Duplicated.IsNull() && !v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectValueMust(
+			DuplicatedValue{}.AttributeTypes(ctx),
+			v.Duplicated.Attributes(),
+		)
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"duplicated": duplicated,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedCustomType1Value) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedCustomType1Value)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Duplicated.Equal(other.Duplicated) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedCustomType1Value) Type(ctx context.Context) attr.Type {
+	return DuplicatedCustomType1Type{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedCustomType1Value) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+}
+
+var _ basetypes.ObjectTypable = DuplicatedType{}
+
+type DuplicatedType struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedType) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedType)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedType) String() string {
+	return "DuplicatedType"
+}
+
+func (t DuplicatedType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	somethingAttribute, ok := attributes["something"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`something is missing from object`)
+
+		return nil, diags
+	}
+
+	somethingVal, ok := somethingAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`something expected to be basetypes.StringValue, was: %T`, somethingAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedValue{
+		Something: somethingVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedValueNull() DuplicatedValue {
+	return DuplicatedValue{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedValueUnknown() DuplicatedValue {
+	return DuplicatedValue{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedValue(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedValue Attribute Value",
+				"While creating a DuplicatedValue value, a missing attribute value was detected. "+
+					"A DuplicatedValue must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedValue Attribute Type",
+				"While creating a DuplicatedValue value, an invalid attribute value was detected. "+
+					"A DuplicatedValue must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedValue Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedValue Attribute Value",
+				"While creating a DuplicatedValue value, an extra attribute value was detected. "+
+					"A DuplicatedValue must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedValue Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	somethingAttribute, ok := attributes["something"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`something is missing from object`)
+
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	somethingVal, ok := somethingAttribute.(basetypes.StringValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`something expected to be basetypes.StringValue, was: %T`, somethingAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedValueUnknown(), diags
+	}
+
+	return DuplicatedValue{
+		Something: somethingVal,
+		state:     attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedValue {
+	object, diags := NewDuplicatedValue(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedValueMust(DuplicatedValue{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedType) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedValue{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedValue{}
+
+type DuplicatedValue struct {
+	Something basetypes.StringValue `tfsdk:"something"`
+	state     attr.ValueState
+}
+
+func (v DuplicatedValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["something"] = basetypes.StringType{}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Something.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["something"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedValue) String() string {
+	return "DuplicatedValue"
+}
+
+func (v DuplicatedValue) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributeTypes := map[string]attr.Type{
+		"something": basetypes.StringType{},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"something": v.Something,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedValue) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedValue)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Something.Equal(other.Something) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedValue) Type(ctx context.Context) attr.Type {
+	return DuplicatedType{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedValue) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"something": basetypes.StringType{},
+	}
+}
+
+var _ basetypes.ObjectTypable = DuplicatedCustomType2Type{}
+
+type DuplicatedCustomType2Type struct {
+	basetypes.ObjectType
+}
+
+func (t DuplicatedCustomType2Type) Equal(o attr.Type) bool {
+	other, ok := o.(DuplicatedCustomType2Type)
+
+	if !ok {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t DuplicatedCustomType2Type) String() string {
+	return "DuplicatedCustomType2Type"
+}
+
+func (t DuplicatedCustomType2Type) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes := in.Attributes()
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return nil, diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	return DuplicatedCustomType2Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType2ValueNull() DuplicatedCustomType2Value {
+	return DuplicatedCustomType2Value{
+		state: attr.ValueStateNull,
+	}
+}
+
+func NewDuplicatedCustomType2ValueUnknown() DuplicatedCustomType2Value {
+	return DuplicatedCustomType2Value{
+		state: attr.ValueStateUnknown,
+	}
+}
+
+func NewDuplicatedCustomType2Value(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) (DuplicatedCustomType2Value, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	for name, attributeType := range attributeTypes {
+		attribute, ok := attributes[name]
+
+		if !ok {
+			diags.AddError(
+				"Missing DuplicatedCustomType2Value Attribute Value",
+				"While creating a DuplicatedCustomType2Value value, a missing attribute value was detected. "+
+					"A DuplicatedCustomType2Value must contain values for all attributes, even if null or unknown. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Expected Type: %s", name, attributeType.String()),
+			)
+
+			continue
+		}
+
+		if !attributeType.Equal(attribute.Type(ctx)) {
+			diags.AddError(
+				"Invalid DuplicatedCustomType2Value Attribute Type",
+				"While creating a DuplicatedCustomType2Value value, an invalid attribute value was detected. "+
+					"A DuplicatedCustomType2Value must use a matching attribute type for the value. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Expected Type: %s\n", name, attributeType.String())+
+					fmt.Sprintf("DuplicatedCustomType2Value Attribute Name (%s) Given Type: %s", name, attribute.Type(ctx)),
+			)
+		}
+	}
+
+	for name := range attributes {
+		_, ok := attributeTypes[name]
+
+		if !ok {
+			diags.AddError(
+				"Extra DuplicatedCustomType2Value Attribute Value",
+				"While creating a DuplicatedCustomType2Value value, an extra attribute value was detected. "+
+					"A DuplicatedCustomType2Value must not contain values beyond the expected attribute types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Extra DuplicatedCustomType2Value Attribute Name: %s", name),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	duplicatedAttribute, ok := attributes["duplicated"]
+
+	if !ok {
+		diags.AddError(
+			"Attribute Missing",
+			`duplicated is missing from object`)
+
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	duplicatedVal, ok := duplicatedAttribute.(basetypes.ObjectValue)
+
+	if !ok {
+		diags.AddError(
+			"Attribute Wrong Type",
+			fmt.Sprintf(`duplicated expected to be basetypes.ObjectValue, was: %T`, duplicatedAttribute))
+	}
+
+	if diags.HasError() {
+		return NewDuplicatedCustomType2ValueUnknown(), diags
+	}
+
+	return DuplicatedCustomType2Value{
+		Duplicated: duplicatedVal,
+		state:      attr.ValueStateKnown,
+	}, diags
+}
+
+func NewDuplicatedCustomType2ValueMust(attributeTypes map[string]attr.Type, attributes map[string]attr.Value) DuplicatedCustomType2Value {
+	object, diags := NewDuplicatedCustomType2Value(attributeTypes, attributes)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewDuplicatedCustomType2ValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return object
+}
+
+func (t DuplicatedCustomType2Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewDuplicatedCustomType2ValueNull(), nil
+	}
+
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+
+	if !in.IsKnown() {
+		return NewDuplicatedCustomType2ValueUnknown(), nil
+	}
+
+	if in.IsNull() {
+		return NewDuplicatedCustomType2ValueNull(), nil
+	}
+
+	attributes := map[string]attr.Value{}
+
+	val := map[string]tftypes.Value{}
+
+	err := in.As(&val)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range val {
+		a, err := t.AttrTypes[k].ValueFromTerraform(ctx, v)
+
+		if err != nil {
+			return nil, err
+		}
+
+		attributes[k] = a
+	}
+
+	return NewDuplicatedCustomType2ValueMust(DuplicatedCustomType2Value{}.AttributeTypes(ctx), attributes), nil
+}
+
+func (t DuplicatedCustomType2Type) ValueType(ctx context.Context) attr.Value {
+	return DuplicatedCustomType2Value{}
+}
+
+var _ basetypes.ObjectValuable = DuplicatedCustomType2Value{}
+
+type DuplicatedCustomType2Value struct {
+	Duplicated basetypes.ObjectValue `tfsdk:"duplicated"`
+	state      attr.ValueState
+}
+
+func (v DuplicatedCustomType2Value) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	attrTypes := make(map[string]tftypes.Type, 1)
+
+	var val tftypes.Value
+	var err error
+
+	attrTypes["duplicated"] = basetypes.ObjectType{
+		AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+	}.TerraformType(ctx)
+
+	objectType := tftypes.Object{AttributeTypes: attrTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make(map[string]tftypes.Value, 1)
+
+		val, err = v.Duplicated.ToTerraformValue(ctx)
+
+		if err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		vals["duplicated"] = val
+
+		if err := tftypes.ValidateValue(objectType, vals); err != nil {
+			return tftypes.NewValue(objectType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(objectType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(objectType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(objectType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Object state in ToTerraformValue: %s", v.state))
+	}
+}
+
+func (v DuplicatedCustomType2Value) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+func (v DuplicatedCustomType2Value) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+func (v DuplicatedCustomType2Value) String() string {
+	return "DuplicatedCustomType2Value"
+}
+
+func (v DuplicatedCustomType2Value) ToObjectValue(ctx context.Context) (basetypes.ObjectValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	var duplicated basetypes.ObjectValue
+
+	if v.Duplicated.IsNull() {
+		duplicated = types.ObjectNull(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectUnknown(
+			DuplicatedValue{}.AttributeTypes(ctx),
+		)
+	}
+
+	if !v.Duplicated.IsNull() && !v.Duplicated.IsUnknown() {
+		duplicated = types.ObjectValueMust(
+			DuplicatedValue{}.AttributeTypes(ctx),
+			v.Duplicated.Attributes(),
+		)
+	}
+
+	attributeTypes := map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+
+	if v.IsNull() {
+		return types.ObjectNull(attributeTypes), diags
+	}
+
+	if v.IsUnknown() {
+		return types.ObjectUnknown(attributeTypes), diags
+	}
+
+	objVal, diags := types.ObjectValue(
+		attributeTypes,
+		map[string]attr.Value{
+			"duplicated": duplicated,
+		})
+
+	return objVal, diags
+}
+
+func (v DuplicatedCustomType2Value) Equal(o attr.Value) bool {
+	other, ok := o.(DuplicatedCustomType2Value)
+
+	if !ok {
+		return false
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if !v.Duplicated.Equal(other.Duplicated) {
+		return false
+	}
+
+	return true
+}
+
+func (v DuplicatedCustomType2Value) Type(ctx context.Context) attr.Type {
+	return DuplicatedCustomType2Type{
+		basetypes.ObjectType{
+			AttrTypes: v.AttributeTypes(ctx),
+		},
+	}
+}
+
+func (v DuplicatedCustomType2Value) AttributeTypes(ctx context.Context) map[string]attr.Type {
+	return map[string]attr.Type{
+		"duplicated": basetypes.ObjectType{
+			AttrTypes: DuplicatedValue{}.AttributeTypes(ctx),
+		},
+	}
+}
+
+// already written CustomNestedObjectType: duplicated
+// already written CustomNestedObjectValue: duplicated
 
 var _ basetypes.ObjectTypable = ListNestedAttributeAssocExtTypeType{}
 

--- a/internal/datasource/list_nested_attribute.go
+++ b/internal/datasource/list_nested_attribute.go
@@ -170,7 +170,7 @@ func (g GeneratorListNestedAttribute) GetAttributes() schema.GeneratorAttributes
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -181,7 +181,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 	// CustomTypeAndValue interface.
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/datasource/list_nested_block.go
+++ b/internal/datasource/list_nested_block.go
@@ -181,7 +181,7 @@ func (g GeneratorListNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.NestedObject.Blocks
 }
 
-func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorListNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -208,7 +208,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -285,7 +285,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -297,7 +297,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	for _, k := range blockKeys {
 		if c, ok := g.NestedObject.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/datasource/map_nested_attribute.go
+++ b/internal/datasource/map_nested_attribute.go
@@ -170,7 +170,7 @@ func (g GeneratorMapNestedAttribute) GetAttributes() schema.GeneratorAttributes 
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -181,7 +181,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/datasource/set_nested_attribute.go
+++ b/internal/datasource/set_nested_attribute.go
@@ -170,7 +170,7 @@ func (g GeneratorSetNestedAttribute) GetAttributes() schema.GeneratorAttributes 
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -181,7 +181,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/datasource/set_nested_block.go
+++ b/internal/datasource/set_nested_block.go
@@ -181,7 +181,7 @@ func (g GeneratorSetNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.NestedObject.Blocks
 }
 
-func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -208,7 +208,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -285,7 +285,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -297,7 +297,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	for _, k := range blockKeys {
 		if c, ok := g.NestedObject.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/datasource/single_nested_attribute.go
+++ b/internal/datasource/single_nested_attribute.go
@@ -163,7 +163,7 @@ func (g GeneratorSingleNestedAttribute) GetAttributes() schema.GeneratorAttribut
 	return g.Attributes
 }
 
-func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.Attributes.AttrValues()
@@ -174,7 +174,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/datasource/single_nested_block.go
+++ b/internal/datasource/single_nested_block.go
@@ -194,7 +194,7 @@ func (g GeneratorSingleNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.Blocks
 }
 
-func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.Attributes.AttrValues()
@@ -221,7 +221,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -310,7 +310,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	for _, k := range blockKeys {
 		if c, ok := g.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/provider/list_nested_attribute.go
+++ b/internal/provider/list_nested_attribute.go
@@ -170,7 +170,7 @@ func (g GeneratorListNestedAttribute) GetAttributes() schema.GeneratorAttributes
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -181,7 +181,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 	// CustomTypeAndValue interface.
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/provider/list_nested_block.go
+++ b/internal/provider/list_nested_block.go
@@ -181,7 +181,7 @@ func (g GeneratorListNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.NestedObject.Blocks
 }
 
-func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorListNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -208,7 +208,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -285,7 +285,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -297,7 +297,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	for _, k := range blockKeys {
 		if c, ok := g.NestedObject.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/provider/map_nested_attribute.go
+++ b/internal/provider/map_nested_attribute.go
@@ -170,7 +170,7 @@ func (g GeneratorMapNestedAttribute) GetAttributes() schema.GeneratorAttributes 
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -181,7 +181,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/provider/set_nested_attribute.go
+++ b/internal/provider/set_nested_attribute.go
@@ -170,7 +170,7 @@ func (g GeneratorSetNestedAttribute) GetAttributes() schema.GeneratorAttributes 
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -181,7 +181,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/provider/set_nested_block.go
+++ b/internal/provider/set_nested_block.go
@@ -181,7 +181,7 @@ func (g GeneratorSetNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.NestedObject.Blocks
 }
 
-func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -208,7 +208,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -285,7 +285,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -297,7 +297,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	for _, k := range blockKeys {
 		if c, ok := g.NestedObject.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/provider/single_nested_attribute.go
+++ b/internal/provider/single_nested_attribute.go
@@ -163,7 +163,7 @@ func (g GeneratorSingleNestedAttribute) GetAttributes() schema.GeneratorAttribut
 	return g.Attributes
 }
 
-func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.Attributes.AttrValues()
@@ -174,7 +174,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/provider/single_nested_block.go
+++ b/internal/provider/single_nested_block.go
@@ -194,7 +194,7 @@ func (g GeneratorSingleNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.Blocks
 }
 
-func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.Attributes.AttrValues()
@@ -221,7 +221,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -310,7 +310,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	for _, k := range blockKeys {
 		if c, ok := g.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/resource/list_nested_attribute.go
+++ b/internal/resource/list_nested_attribute.go
@@ -194,7 +194,7 @@ func (g GeneratorListNestedAttribute) GetAttributes() schema.GeneratorAttributes
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -205,7 +205,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -233,7 +233,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -247,7 +247,7 @@ func (g GeneratorListNestedAttribute) CustomTypeAndValue(name string) ([]byte, e
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/resource/list_nested_block.go
+++ b/internal/resource/list_nested_block.go
@@ -194,7 +194,7 @@ func (g GeneratorListNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.NestedObject.Blocks
 }
 
-func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorListNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -221,7 +221,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -310,7 +310,7 @@ func (g GeneratorListNestedBlock) CustomTypeAndValue(name string) ([]byte, error
 
 	for _, k := range blockKeys {
 		if c, ok := g.NestedObject.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/resource/map_nested_attribute.go
+++ b/internal/resource/map_nested_attribute.go
@@ -194,7 +194,7 @@ func (g GeneratorMapNestedAttribute) GetAttributes() schema.GeneratorAttributes 
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -205,7 +205,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -233,7 +233,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -247,7 +247,7 @@ func (g GeneratorMapNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/resource/set_nested_attribute.go
+++ b/internal/resource/set_nested_attribute.go
@@ -194,7 +194,7 @@ func (g GeneratorSetNestedAttribute) GetAttributes() schema.GeneratorAttributes 
 	return g.NestedObject.Attributes
 }
 
-func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -205,7 +205,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -233,7 +233,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -247,7 +247,7 @@ func (g GeneratorSetNestedAttribute) CustomTypeAndValue(name string) ([]byte, er
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/resource/set_nested_block.go
+++ b/internal/resource/set_nested_block.go
@@ -194,7 +194,7 @@ func (g GeneratorSetNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.NestedObject.Blocks
 }
 
-func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.NestedObject.Attributes.AttrValues()
@@ -221,7 +221,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.NestedObject.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -310,7 +310,7 @@ func (g GeneratorSetNestedBlock) CustomTypeAndValue(name string) ([]byte, error)
 
 	for _, k := range blockKeys {
 		if c, ok := g.NestedObject.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/resource/single_nested_attribute.go
+++ b/internal/resource/single_nested_attribute.go
@@ -185,7 +185,7 @@ func (g GeneratorSingleNestedAttribute) GetAttributes() schema.GeneratorAttribut
 	return g.Attributes
 }
 
-func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.Attributes.AttrValues()
@@ -196,7 +196,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 
 	objectType := schema.NewCustomNestedObjectType(name, attributeAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -224,7 +224,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributeTypes, attributeAttrTypes, attributeAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -238,7 +238,7 @@ func (g GeneratorSingleNestedAttribute) CustomTypeAndValue(name string) ([]byte,
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/resource/single_nested_block.go
+++ b/internal/resource/single_nested_block.go
@@ -205,7 +205,7 @@ func (g GeneratorSingleNestedBlock) GetBlocks() schema.GeneratorBlocks {
 	return g.Blocks
 }
 
-func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, error) {
+func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string, renderstate *schema.RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeAttrValues, err := g.Attributes.AttrValues()
@@ -232,7 +232,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	objectType := schema.NewCustomNestedObjectType(name, attributesBlocksAttrValues)
 
-	b, err := objectType.Render()
+	b, err := objectType.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -293,7 +293,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	objectValue := schema.NewCustomNestedObjectValue(name, attributesBlocksTypes, attributesBlocksAttrTypes, attributesBlocksAttrValues, attributeCollectionTypes)
 
-	b, err = objectValue.Render()
+	b, err = objectValue.Render(renderstate)
 
 	if err != nil {
 		return nil, err
@@ -309,7 +309,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 	// CustomTypeAndValue interface (i.e, nested attributes).
 	for _, k := range attributeKeys {
 		if c, ok := g.Attributes[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -321,7 +321,7 @@ func (g GeneratorSingleNestedBlock) CustomTypeAndValue(name string) ([]byte, err
 
 	for _, k := range blockKeys {
 		if c, ok := g.Blocks[k].(schema.CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/schema/custom_nested_object.go
+++ b/internal/schema/custom_nested_object.go
@@ -42,8 +42,50 @@ func NewCustomNestedObjectType(name string, attrValues map[string]string) Custom
 	}
 }
 
-func (c CustomNestedObjectType) Render() ([]byte, error) {
+// Holds sets of already rendered custom type elements that are used
+// to prevent rendering them more than once per run.
+type RenderState struct {
+	CustomNestedObjectTypeRendered  map[FrameworkIdentifier]struct{}
+	CustomNestedObjectValueRendered map[FrameworkIdentifier]struct{}
+}
+
+// Creates a new RenderState
+func NewRenderState() RenderState {
+	return RenderState{
+		CustomNestedObjectTypeRendered:  make(map[FrameworkIdentifier]struct{}),
+		CustomNestedObjectValueRendered: make(map[FrameworkIdentifier]struct{}),
+	}
+}
+
+// Returns true if the given 'name' has already been rendered
+func (rs *RenderState) CheckCustomNestedObjectType(name FrameworkIdentifier) bool {
+	if _, ok := rs.CustomNestedObjectTypeRendered[name]; ok {
+		return true
+	} else {
+		rs.CustomNestedObjectTypeRendered[name] = struct{}{}
+		return false
+	}
+}
+
+// Returns true if the given 'name' has already been rendered
+func (rs *RenderState) CheckCustomNestedObjectValue(name FrameworkIdentifier) bool {
+	if _, ok := rs.CustomNestedObjectValueRendered[name]; ok {
+		return true
+
+	} else {
+		rs.CustomNestedObjectValueRendered[name] = struct{}{}
+		return false
+	}
+}
+
+func (c CustomNestedObjectType) Render(state *RenderState) ([]byte, error) {
 	var buf bytes.Buffer
+
+	// only render things 1x
+	if state.CheckCustomNestedObjectType(c.Name) {
+		buf.Write([]byte("\n// already written CustomNestedObjectType: " + c.Name + "\n"))
+		return buf.Bytes(), nil
+	}
 
 	renderFuncs := []func() ([]byte, error){
 		c.renderTypable,
@@ -377,8 +419,13 @@ func NewCustomNestedObjectValue(name string, attributeTypes, attrTypes, attrValu
 	}
 }
 
-func (c CustomNestedObjectValue) Render() ([]byte, error) {
+func (c CustomNestedObjectValue) Render(state *RenderState) ([]byte, error) {
 	var buf bytes.Buffer
+
+	if state.CheckCustomNestedObjectValue(c.Name) {
+		buf.Write([]byte("// already written CustomNestedObjectValue: " + c.Name + "\n"))
+		return buf.Bytes(), nil
+	}
 
 	renderFuncs := []func() ([]byte, error){
 		c.renderValuable,

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -244,7 +244,7 @@ func (g GeneratorSchema) Models(name string) ([]model.Model, error) {
 
 // CustomTypeValueBytes iterates over all the attributes and blocks to generate code
 // for custom type and value types for use in the schema and data models.
-func (g GeneratorSchema) CustomTypeValueBytes() ([]byte, error) {
+func (g GeneratorSchema) CustomTypeValueBytes(renderstate *RenderState) ([]byte, error) {
 	var buf bytes.Buffer
 
 	attributeKeys := g.Attributes.SortedKeys()
@@ -255,7 +255,7 @@ func (g GeneratorSchema) CustomTypeValueBytes() ([]byte, error) {
 		}
 
 		if c, ok := g.Attributes[k].(CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err
@@ -273,7 +273,7 @@ func (g GeneratorSchema) CustomTypeValueBytes() ([]byte, error) {
 		}
 
 		if c, ok := g.Blocks[k].(CustomTypeAndValue); ok {
-			b, err := c.CustomTypeAndValue(k)
+			b, err := c.CustomTypeAndValue(k, renderstate)
 
 			if err != nil {
 				return nil, err

--- a/internal/schema/schemas.go
+++ b/internal/schema/schemas.go
@@ -75,11 +75,11 @@ func (g GeneratorSchemas) Models() (map[string][]byte, error) {
 	return modelsBytes, nil
 }
 
-func (g GeneratorSchemas) CustomTypeValue() (map[string][]byte, error) {
+func (g GeneratorSchemas) CustomTypeValue(renderstate *RenderState) (map[string][]byte, error) {
 	customTypeValueBytes := make(map[string][]byte, len(g.schemas))
 
 	for name, s := range g.schemas {
-		b, err := s.CustomTypeValueBytes()
+		b, err := s.CustomTypeValueBytes(renderstate)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -23,7 +23,7 @@ type Blocks interface {
 }
 
 type CustomTypeAndValue interface {
-	CustomTypeAndValue(name string) ([]byte, error)
+	CustomTypeAndValue(name string, renderstate *RenderState) ([]byte, error)
 }
 
 type Elements interface {


### PR DESCRIPTION
Changes custom_nested_object rendering so that it will only render each time only once per run.  This avoid go compilation errors related to duplicate symbols.